### PR TITLE
fix "No package matching 'memcached_redhat_pkgs' found available"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -2,12 +2,12 @@
 
 - name: install the memcached packages
   yum: name={{ item }} state=present
-  with_items: memcached_redhat_pkgs
+  with_items: "{{ memcached_redhat_pkgs }}"
   when: ansible_os_family == "RedHat"
 
 - name: install the memcached packages
   apt: name={{ item }} state=present update_cache=yes
-  with_items: memcached_ubuntu_pkgs
+  with_items: "{{ memcached_ubuntu_pkgs }}"
   environment: env
   when: ansible_os_family == "Debian"
 


### PR DESCRIPTION
fixes an error generated by cchurch.memcached (on ansible 2.3.2.0) with the following params:

```memcached_max_conn: 8192, memcached_cache_size: 256, memcached_options: '-U 11211 -t 4'```

The error is:

```
TASK [cchurch.memcached : install the memcached packages] ***********************************************************************************************************************************************************
failed: [rhsm01.devlab.redhat.com] (item=[u'memcached_redhat_pkgs']) => {"changed": false, "failed": true, "item": ["memcached_redhat_pkgs"], "msg": "No package matching 'memcached_redhat_pkgs' found available, installed or updated", "rc": 126, "results": ["No package matching 'memcached_redhat_pkgs' found available, installed or updated"]}
```